### PR TITLE
enable test and lint checks

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -3,8 +3,7 @@ name: Elevatorian SDLC - Pull Request
 on:
   push:
     branches:
-      - '*'
-      - '!main'
+      - 'main'
 
 jobs:
   checks:
@@ -23,6 +22,6 @@ jobs:
       - run: yarn install --frozen-lockfile
       # parellelization will speed up the build a little
       # concurrency=2 for the expected 2 apps we have (web, express)
-      - run: yarn nx affected --target=build --parallel=2
-      - run: yarn nx affected --target=lint --parallel=2
-      - run: yarn nx affected --target=test --parallel=2
+      - run: yarn nx run-many --target=build --parallel=2
+      - run: yarn nx run-many --target=lint --parallel=2
+      - run: yarn nx run-many --target=test --parallel=2

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,4 +1,4 @@
-name: Elevatorian SDLC - Pull Request
+name: Elevatorian SDLC - Production
 
 on:
   push:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,8 @@ jobs:
       # see https://nx.dev/using-nx/affected
       - uses: nrwl/nx-set-shas@v2
       - run: yarn install --frozen-lockfile
-      # parellelize by 2 for now, it will speed up the build a little, and
-      # we only have 2 apps right now
+      # parellelization will speed up the build a little
+      # concurrency=2 for the expected 2 apps we have (web, express)
       - run: yarn nx affected --target=build --parallel=2
+      - run: yarn nx affected --target=lint --parallel=2
+      - run: yarn nx affected --target=test --parallel=2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,8 @@ on:
       - '!main'
 
 jobs:
+  # the name here is important; github repo settings are watching for this
+  # specific key to know what checks to guard PR merging on
   checks:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
closes #21 

## Summary

- Enables `lint` and `test` checks on all PRs

## Technical Notes

- As a side note, currently `lint` and `test` don't pass on some projects. However, the `affected` command is working correctly, and not building/linting/testing those projects in the PR, since it isn't changed!